### PR TITLE
Update store template action handling 

### DIFF
--- a/store/templates/store.js
+++ b/store/templates/store.js
@@ -38,7 +38,7 @@ var <%= name %> = merge(EventEmitter.prototype, {
     var action = payload.action;
 
     switch(action.type) {
-      case Constants.UPDATE_TITLE:
+      case Constants.ActionTypes.UPDATE_TITLE:
         var text = action.text.trim();
         // NOTE: if this action needs to wait on another store:
         // <%= name %>.waitFor([OtherStore.dispatchToken]);


### PR DESCRIPTION
I think this was coincidentally working before because both `action.actionType` and `Constants.UPDATE_TITLE` were `undefined`. 
