### PR TITLE
Chore: 6to5 renamed into Babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It's an "Application Architecture for Building User Interfaces", built by the te
 - [x] Facebook's Flux architecture (using official [dispatcher](https://github.com/facebook/flux/blob/master/src/Dispatcher.js))
 - [x] [Gulp](http://gulpjs.com/) for builds
 - [x] [Browserify](http://browserify.org/) and CJS modules
-- [x] [6to5](https://6to5.org/) for es6 transpilation
+- [x] [Babel](https://babeljs.io/) for es6 transpilation
 - [x] Static server with livereload
 - [x] SASS CSS preprocessor
 

--- a/app/index.js
+++ b/app/index.js
@@ -107,13 +107,13 @@ var FluxGenerator = yeoman.generators.Base.extend({
   },
 
   testing: function() {
-    this.npmInstall(['jest-cli', '6to5-jest'], { saveDev: true });
+    this.npmInstall(['jest-cli', 'babel-jest'], { saveDev: true });
     this.mkdir('src/js/stores/__tests__');
     this.mkdir('src/js/components/__tests__');
   },
 
   transpilation: function() {
-    this.npmInstall(['6to5ify'], { 'saveDev': true })
+    this.npmInstall(['babelify'], { 'saveDev': true })
   },
 
   styles: function() {

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -14,7 +14,7 @@
     "test": "jest"
   },
   "jest": {
-    "scriptPreprocessor": "<rootDir>/node_modules/6to5-jest",
+    "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
     "testFileExtensions": [
       "es6",
       "js"

--- a/app/templates/gulp/config.js
+++ b/app/templates/gulp/config.js
@@ -22,7 +22,7 @@ module.exports = {
   },
   browserify: {
     settings: {
-      transform: ['reactify', '6to5ify']
+      transform: ['reactify', 'babelify']
     },
     src: src + '/js/index.jsx',
     dest: dest + '/js',


### PR DESCRIPTION
6to5 has been renamed to babel:
https://babeljs.io/blog/2015/02/15/not-born-to-die/