### PR TITLE
Source maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ The generated project includes a live-reloading static server on port `8080` (yo
 $ npm start
 ```
 
+To run the live-reloading static server on port `8080` with source maps enabled (don't use source maps for production!), run: 
+
+```bash
+$ npm run dev
+```
+
 If you prefer to just build without the live reload and build-on-each-change watcher, run:
 
 ```bash

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -9,6 +9,7 @@
   },
 
   "scripts": {
+    "dev": "gulp --type dev",
     "start": "gulp",
     "build": "gulp build"
   },

--- a/app/templates/gulp/config.js
+++ b/app/templates/gulp/config.js
@@ -27,6 +27,7 @@ module.exports = {
     src: src + '/js/index.jsx',
     dest: dest + '/js',
     outputName: 'index.js',
+    debug: false
   },
   html: {
     src: 'src/index.html',

--- a/app/templates/gulp/config.js
+++ b/app/templates/gulp/config.js
@@ -1,5 +1,6 @@
 var dest = './dist';
 var src = './src';
+var gutil = require('gulp-util');
 
 module.exports = {
   server: {
@@ -27,7 +28,7 @@ module.exports = {
     src: src + '/js/index.jsx',
     dest: dest + '/js',
     outputName: 'index.js',
-    debug: false
+    debug: gutil.env.type === 'dev'
   },
   html: {
     src: 'src/index.html',

--- a/app/templates/gulp/tasks/browserify.js
+++ b/app/templates/gulp/tasks/browserify.js
@@ -7,6 +7,7 @@ var watchify = require('watchify');
 var connect = require('gulp-connect');
 var config = require('../config').browserify;
 
+watchify.args.debug = config.debug;
 var bundler = watchify(browserify(config.src, watchify.args));
 config.settings.transform.forEach(function(t) {
   bundler.transform(t);


### PR DESCRIPTION
I added another run command which enables source maps in browserify.

I made it a new command because I felt source maps should be opt in, however, developing without them is tedious.