### PR TITLE
Run babelify before reactify

### DIFF
--- a/app/templates/gulp/config.js
+++ b/app/templates/gulp/config.js
@@ -23,7 +23,7 @@ module.exports = {
   },
   browserify: {
     settings: {
-      transform: ['reactify', 'babelify']
+      transform: ['babelify', 'reactify']
     },
     src: src + '/js/index.jsx',
     dest: dest + '/js',


### PR DESCRIPTION
If reactify gets run first, ES6 syntax not supported by
reactify (hit this error with using the import syntax) causes parse errors.