### PR TITLE
slightly refactored watchify in browserify gulp task to resolve issue with re-bundling

### DIFF
--- a/app/templates/gulp/tasks/browserify.js
+++ b/app/templates/gulp/tasks/browserify.js
@@ -7,8 +7,7 @@ var watchify = require('watchify');
 var connect = require('gulp-connect');
 var config = require('../config').browserify;
 
-var b = browserify({ cache: {}, packageCache: {}, debug: config.debug });
-b.add(config.src);
+var b = browserify(config.src, { cache: {}, packageCache: {}, debug: config.debug });
 config.settings.transform.forEach(function(t) {
   b.transform(t);
 });

--- a/app/templates/gulp/tasks/browserify.js
+++ b/app/templates/gulp/tasks/browserify.js
@@ -7,17 +7,18 @@ var watchify = require('watchify');
 var connect = require('gulp-connect');
 var config = require('../config').browserify;
 
-watchify.args.debug = config.debug;
-var bundler = watchify(browserify(config.src, watchify.args));
+var b = browserify({ cache: {}, packageCache: {}, debug: config.debug });
+b.add(config.src);
 config.settings.transform.forEach(function(t) {
-  bundler.transform(t);
+  b.transform(t);
 });
+var w = watchify(b);
 
 gulp.task('browserify', bundle);
-bundler.on('update', bundle);
+w.on('update', bundle);
 
-function bundle() {
-  return bundler.bundle()
+function bundle(){
+  return w.bundle()
   // log errors if they happen
   .on('error', gutil.log.bind(gutil, 'Browserify Error'))
   .pipe(source(config.outputName))


### PR DESCRIPTION
Hi, I was getting a strange issue with the `browserify` gulp task, when triggered following a `gulp.watch()` src file change. The bundle would re-build but would not reflect the changes to the src files, but this only happened with the js not with changes to html or css. So I've tweaked the way you construct browserify and the watchify wrapper (now a bit more like the watchify docs) and it appears to have fixed my issue. 

I realise you need to have watchify as well as `gulp.watch()` to speed up the re-bundling, as per [here](https://github.com/gulpjs/gulp/blob/master/docs/recipes/fast-browserify-builds-with-watchify.md)

Would be good to know if you can recreate this error with your existing generated code, and whether the pull request makes a difference.