### PR TITLE
Implement vinyl-buffer for browserify gulp task

### DIFF
--- a/app/templates/gulp/tasks/browserify.js
+++ b/app/templates/gulp/tasks/browserify.js
@@ -21,6 +21,7 @@ function bundle() {
   // log errors if they happen
   .on('error', gutil.log.bind(gutil, 'Browserify Error'))
   .pipe(source(config.outputName))
+  .pipe(buffer())
   .pipe(gulp.dest(config.dest))
   .pipe(connect.reload());
 }


### PR DESCRIPTION
Hey there, saw that `viny-buffer` was a required dependency but wasn't being used in this file where it was required.  Don't know if you still planned to use it, thought I'd go ahead and add it.