### PR TITLE
keyMirror and react-dom issue resolved; updated react version

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -80,7 +80,7 @@ var FluxGenerator = yeoman.generators.Base.extend({
 
   npm: function() {
     this.npmInstall([
-      'react@0.13', 'flux', 'object-assign', 'eslint', 'babel-eslint',
+      'react', 'react-dom', 'keymirror', 'flux', 'object-assign', 'eslint', 'babel-eslint',
       'eslint-plugin-react', 'gulp-eslint', 'eslint-config-airbnb'
     ], { save: true });
   },

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -7,7 +7,11 @@
   "devDependencies": {
     "gulp": "^3.8.7"
   },
-
+  "dependencies":{
+    "keymirror": "^0.1.1",
+    "react": "^15.0.2",
+    "react-dom": "^15.0.2"
+  },
   "scripts": {
     "dev": "gulp --type dev",
     "start": "gulp",

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -7,11 +7,7 @@
   "devDependencies": {
     "gulp": "^3.8.7"
   },
-  "dependencies":{
-    "keymirror": "^0.1.1",
-    "react": "^15.0.2",
-    "react-dom": "^15.0.2"
-  },
+
   "scripts": {
     "dev": "gulp --type dev",
     "start": "gulp",

--- a/app/templates/js/constants.js
+++ b/app/templates/js/constants.js
@@ -1,4 +1,4 @@
-import keyMirror from 'react/lib/keyMirror';
+import keyMirror from 'keymirror';
 
 export default {
   // event name triggered from store, listened to by views

--- a/app/templates/js/index.jsx
+++ b/app/templates/js/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import ReactDOM from 'react-dom';
 import AppContainer from './components/AppContainer.jsx';
 
-React.render(<AppContainer />, document.getElementById('main'));
+ReactDOM.render(<AppContainer />, document.getElementById('main'));


### PR DESCRIPTION
On using the generator and updating the React version to latest, it threw errors on `keyMirror` and `render`.

Added `react-dom` as dependency and used render method from it.

`keymirror` is also available as a detached package, added as dependency and used in the constants template.
